### PR TITLE
Bugfix: With this bugfix you don't need to add retry to the code as the lambda_loader.sh returns only the necessary json format response

### DIFF
--- a/lambda_loader.sh
+++ b/lambda_loader.sh
@@ -15,7 +15,7 @@ export ENABLED_FUNCTION="${ENABLED_FUNCTION}"
 
 if [ ! -d "${DESTINATION}" ]; then
   curl -s "${FUNCTION_BEAT_URL}" > "${DESTINATION}".tar.gz
-  tar xzvf "${DESTINATION}".tar.gz
+  tar xzvf "${DESTINATION}".tar.gz > /dev/null
   rm -rf "${DESTINATION}".tar.gz
 fi
 
@@ -24,6 +24,7 @@ cp -f "${CONFIG_FILE}" "${DESTINATION}"/functionbeat.yml
 cd "${DESTINATION}"
 ./functionbeat -v -e package --output ./../"${DESTINATION}-release".zip
 
+cd ..
 rm -rf "${DESTINATION}"
 
 jq -M -c -n --arg destination "${DESTINATION}-release.zip" '{"filename": $destination}'


### PR DESCRIPTION
I edited the code of the lambda_loader.sh as it was returning the unziped files by the stout to the terraform so that's why the first time executing the module it fails and the retry was added.
With this change there is no need of retry.