### PR TITLE
Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,6 @@ variable "functionbeat_version" {
   description = "Funtionbeat version to deploy"
   type        = string
   validation {
-    #condition     = tonumber(substr(var.functionbeat_version, 1, 1)) >= 8 && tonumber(substr(var.functionbeat_version, 3, 2)) >= 12 && tonumber(substr(var.functionbeat_version, 6, 1)) >= 1
     condition     = tonumber(split(".", var.functionbeat_version)[0]) >= 8 && tonumber(split(".", var.functionbeat_version)[1]) >= 12 && tonumber(split(".", var.functionbeat_version)[2]) >= 1
     error_message = "The functionbeat_version must be at least '8.12.1' to be able to use the provided.al2 aws lambda runtime."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "functionbeat_version" {
   validation {
     #condition     = tonumber(substr(var.functionbeat_version, 1, 1)) >= 8 && tonumber(substr(var.functionbeat_version, 3, 2)) >= 12 && tonumber(substr(var.functionbeat_version, 6, 1)) >= 1
     condition     = tonumber(split(".", var.functionbeat_version)[0]) >= 8 && tonumber(split(".", var.functionbeat_version)[1]) >= 12 && tonumber(split(".", var.functionbeat_version)[2]) >= 1
-    error_message = "The functionbeat_version must be at leat v8.12.1 to be able to use the provided.al2 aws lambda runtime."
+    error_message = "The functionbeat_version must be at least '8.12.1' to be able to use the provided.al2 aws lambda runtime."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,8 @@ variable "functionbeat_version" {
   description = "Funtionbeat version to deploy"
   type        = string
   validation {
-    condition     = tonumber(substr(var.functionbeat_version, 1, 1)) >= 8 && tonumber(substr(var.functionbeat_version, 3, 2)) >= 12 && tonumber(substr(var.functionbeat_version, 6, 1)) >= 1
+    #condition     = tonumber(substr(var.functionbeat_version, 1, 1)) >= 8 && tonumber(substr(var.functionbeat_version, 3, 2)) >= 12 && tonumber(substr(var.functionbeat_version, 6, 1)) >= 1
+    condition     = tonumber(split(".", var.functionbeat_version)[0]) >= 8 && tonumber(split(".", var.functionbeat_version)[1]) >= 12 && tonumber(split(".", var.functionbeat_version)[2]) >= 1
     error_message = "The functionbeat_version must be at leat v8.12.1 to be able to use the provided.al2 aws lambda runtime."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "functionbeat_version" {
   description = "Funtionbeat version to deploy"
   type        = string
   validation {
-    condition     = substr(var.functionbeat_version, 1, 1) >= "8" && substr(var.functionbeat_version, 3, 2) >= "12" && substr(var.functionbeat_version, 6, 1) >= "1"
+    condition     = tonumber(substr(var.functionbeat_version, 1, 1)) >= 8 && tonumber(substr(var.functionbeat_version, 3, 2)) >= 12 && tonumber(substr(var.functionbeat_version, 6, 1)) >= 1
     error_message = "The functionbeat_version must be at leat v8.12.1 to be able to use the provided.al2 aws lambda runtime."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,10 @@ variable "application_name" {
 variable "functionbeat_version" {
   description = "Funtionbeat version to deploy"
   type        = string
+  validation {
+    condition     = substr(var.functionbeat_version, 1, 1) >= "8" && substr(var.functionbeat_version, 3, 2) >= "12" && substr(var.functionbeat_version, 6, 1) >= "1"
+    error_message = "The functionbeat_version must be at leat v8.12.1 to be able to use the provided.al2 aws lambda runtime."
+  }
 }
 
 variable "lambda_config" {


### PR DESCRIPTION
since v8.12.1, beats bumped the aws-lambda-go package to 1.44.0

see https://github.com/elastic/beats/compare/v8.12.0...v8.12.1#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6

 This fixes the issue of functionbeat not running on the provided.al2 runtime, which is to be used i favor of the go runtime.