### PR TITLE
Module maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Since this module executes a script ensure your machine has the following softwa
 * tar
 * zip
 * unzip
+* openssl
 
 ### Running under Alpine ###
 :information_source: 
@@ -87,6 +88,9 @@ Head over to `example/elasticsearch/elasticsearch.tf`  or `example/logstash/logs
 | lambda_timeout                       |     -    | Timeout (default: 3s)                                                                                                                |
 | lambda_description                   |     -    | Description added to the Lambda (default: "Lambda function to ship cloudwatch logs to Kibana")                                       |
 | lambda_write_arn_to_ssm              |     -    | Switch to control weather the actual Lambda ARN should be written to SSM (default:true)                                              |
+| lambda_runtime                       |     -    | Runtime for the Lambda function (default: "provided.al2023")                                                                         |
+| lambda_architecture                  |     -    | Architecture for the Lambda function (default: "x86_64")                                                                             |
+| functionbeat_cache_dir               |     -    | Directory used to cache the Functionbeat archive and config files (default: `${path.root}/.terraform/functionbeat`)                  |
 | fb_log_level                         |     -    | Functionbeat loglevel, will be set as an ENV on the Lambda level for easy adjustion (default: info)                                  |
 | fb_extra_configuration               |     -    | HCL-Map with actual Functionbeat config (default: {})                                                                                |
 | fb_extra_tags                        |     -    | The tags of the shipper are included in their own field with each transaction published (default: [])                                |

--- a/lambda_loader.sh
+++ b/lambda_loader.sh
@@ -4,7 +4,8 @@ set -e
 eval "$(jq -er '@sh "VERSION=\(.version)
                     ENABLED_FUNCTION=\(.enabled_function)
                     ARCHITECTURE=\(.architecture)
-                    CACHE_DIR=\(.cache_dir)"')"
+                    CACHE_DIR=\(.cache_dir)
+                    FUNCTIONBEAT_YML=\(.functionbeat_yml)"')"
 
 SYSTEM="$(uname | awk '{print tolower($0)}')"
 FUNCTION_BEAT_URL=https://artifacts.elastic.co/downloads/beats/functionbeat/functionbeat-"${VERSION}"-"${SYSTEM}"-"${ARCHITECTURE}".tar.gz
@@ -27,7 +28,7 @@ cd "${CACHE_DIR}/${ENABLED_FUNCTION}"
 
 tar xzvf "../${DESTINATION}".tar.gz > /dev/null
 
-cp -f "functionbeat.yml" "${DESTINATION}"/functionbeat.yml
+echo "${FUNCTIONBEAT_YML}" | base64 -d > "${DESTINATION}"/functionbeat.yml
 
 cd "${DESTINATION}"
 ./functionbeat -v -e package --output ./../"${DESTINATION}-release".zip

--- a/lambda_loader.sh
+++ b/lambda_loader.sh
@@ -3,23 +3,31 @@ set -e
 
 eval "$(jq -er '@sh "VERSION=\(.version)
                     ENABLED_FUNCTION=\(.enabled_function)
-                    CONFIG_FILE=\(.config_file)"')"
+                    ARCHITECTURE=\(.architecture)
+                    CACHE_DIR=\(.cache_dir)"')"
 
 SYSTEM="$(uname | awk '{print tolower($0)}')"
-FUNCTION_BEAT_URL=https://artifacts.elastic.co/downloads/beats/functionbeat/functionbeat-"${VERSION}"-"${SYSTEM}"-x86_64.tar.gz
+FUNCTION_BEAT_URL=https://artifacts.elastic.co/downloads/beats/functionbeat/functionbeat-"${VERSION}"-"${SYSTEM}"-"${ARCHITECTURE}".tar.gz
 
-DESTINATION=functionbeat-"${VERSION}"-"${SYSTEM}"-x86_64
+DESTINATION=functionbeat-"${VERSION}"-"${SYSTEM}"-"${ARCHITECTURE}"
 
 export BEAT_STRICT_PERMS=false
 export ENABLED_FUNCTION="${ENABLED_FUNCTION}"
 
-if [ ! -d "${DESTINATION}" ]; then
-  curl -s "${FUNCTION_BEAT_URL}" > "${DESTINATION}".tar.gz
-  tar xzvf "${DESTINATION}".tar.gz > /dev/null
-  rm -rf "${DESTINATION}".tar.gz
+mkdir -p "${CACHE_DIR}/${ENABLED_FUNCTION}"
+
+# download functionbeat if not already in cache
+if [ ! -f "${CACHE_DIR}/${DESTINATION}.tar.gz" ]; then
+  mkdir -p "${CACHE_DIR}"
+  curl -s -o "${CACHE_DIR}/${ENABLED_FUNCTION}/${DESTINATION}.tar.gz.tmp" "${FUNCTION_BEAT_URL}"
+  mv "${CACHE_DIR}/${ENABLED_FUNCTION}/${DESTINATION}.tar.gz.tmp" "${CACHE_DIR}/${DESTINATION}.tar.gz"
 fi
 
-cp -f "${CONFIG_FILE}" "${DESTINATION}"/functionbeat.yml
+cd "${CACHE_DIR}/${ENABLED_FUNCTION}"
+
+tar xzvf "../${DESTINATION}".tar.gz > /dev/null
+
+cp -f "functionbeat.yml" "${DESTINATION}"/functionbeat.yml
 
 cd "${DESTINATION}"
 ./functionbeat -v -e package --output ./../"${DESTINATION}-release".zip
@@ -35,9 +43,10 @@ mv functionbeat-aws bootstrap
 chmod go-w functionbeat.yml
 cd ..
 
-zip -j -q "${DESTINATION}"-release.zip "${DESTINATION}"-release/*
+# zip destination contents and with deterministic file order
+find "${DESTINATION}"-release/* -type f | LC_ALL=C sort | zip -j -q -X -@ "${DESTINATION}"-release.zip
 rm -rf "${DESTINATION}"-release
 
-cd ..
+FILEHASH=$(openssl dgst -binary -sha256 "${DESTINATION}-release.zip" | openssl base64)
 
-jq -M -c -n --arg destination "${DESTINATION}-release.zip" '{"filename": $destination}'
+jq -M -c -n --arg filehash "$FILEHASH" --arg destination "${PWD}/${DESTINATION}-release.zip" '{"filename": $destination, "filehash": $filehash}'

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,24 @@ variable "lambda_write_arn_to_ssm" {
   default     = true
 }
 
+variable "lambda_runtime" {
+  description = "Runtime for the Lambda function. Default is 'provided.al2023' which is required for Functionbeat version 8.12.1 and above."
+  type        = string
+  default     = "provided.al2023"
+}
+
+variable "lambda_architecture" {
+  description = "Architecture for the Lambda function. Default is 'x86_64' other runtimes are not tested"
+  type        = string
+  default     = "x86_64"
+}
+
+variable "functionbeat_cache_dir" {
+  description = "Directory used to cache the Functionbeat archive and store generated config files. Defaults to .terraform/functionbeat under the root module."
+  type        = string
+  default     = null
+}
+
 # ============================== Extra Functionbeat ===============================
 
 variable "fb_extra_configuration" {


### PR DESCRIPTION
Hi,

I am working with this module for years. Even though functionbeat is not developed anymore, we have a pain getting away from it. 

It would be really great if you could include my changes:

## 1. guarantee reproducible builds even when using module multiple times

* renames the resulting zip file
* adds the file contents in reproducible order
* computes the filehash in the script to prevent terraform from reading it before creating a new version

## 2. Upgrade to latest provided.al version to fix aws deprecation

* updates the lambda runtime from `provided.al2` to `provided.al2023 to prevent deprecation (planned in July 2026)
  _Worth metioning: I already tested this and it worked out of the box in my environment_

## 3. make architecture and runtime configurable

* introduces two new optional variables for the module `lambda_architecture` and `lambda_runtime` which should reduce maintenance of this module. I did not test the `lambda_architecture` but it should be possible to set it to arm64 if you can execute the arm64 binary on your machine.

## 4. cache functionbeat release archive locally

This is probably something we can leave out if it is controversial. I just recognized that downloading the zip multiple times in a plan where I instantiated the module multiple times on every terraform apply took some time. Probably the release from elastic will never change again. This would also make it possible to provide your own zip if for some reason elastic makes it unavailable.

I changed to folder for all created files (functionbeat.yml and zip) of this repo to be relative to `${module.root}}/.functionbeat`. I thought of making this configurable, not sure if this change is a good idea. I just wanted to make sure it is not stored in the modules folder as this will get deleted on occasions.