### PR TITLE
fix: make lambda_loader.sh portable across Linux and macOS, fail fast on host/lambda arch mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ The Functionbeat installer is not compatible with Alpine, due to missing libc. T
 eg. in a CI pipeline, you need to provide the missing dependencies. 
 You can install libc6-compat using ``apk add --no-cache libc6-compat``. 
 
+### Host platform compatibility ###
+:warning:
+Functionbeat does not support cross-architecture packaging — the host's `functionbeat-aws`
+binary is bundled into the Lambda zip as-is. The host running `terraform apply` must
+therefore match `var.lambda_architecture`:
+
+| Host | `lambda_architecture = "x86_64"` | `lambda_architecture = "arm64"` |
+|------|----------------------------------|---------------------------------|
+| Linux x86_64           | ✓ | ✗ |
+| Linux arm64 / aarch64  | ✗ | ✓ |
+| macOS Intel (x86_64)   | ✓ | ✗ |
+| macOS Apple Silicon    | ✗ (no darwin-arm64 build is published by Elastic) | ✗ |
+
+Building arm64 Lambdas from a non-arm64 host requires running the module from inside
+a matching container (e.g. linux/arm64).
+
 ## Simple example ##
 
 For detailed example please refer to this [blog post](https://medium.com/@pascal-euhus/terraform-functionbeat-e481554d729e) using Elasticsearch output

--- a/lambda_loader.sh
+++ b/lambda_loader.sh
@@ -8,7 +8,6 @@ eval "$(jq -er '@sh "VERSION=\(.version)
                     FUNCTIONBEAT_YML=\(.functionbeat_yml)"')"
 
 SYSTEM="$(uname | awk '{print tolower($0)}')"
-ABSOLUTE_CACHE_DIR="$(realpath -m "${CACHE_DIR}")"
 FUNCTION_BEAT_URL=https://artifacts.elastic.co/downloads/beats/functionbeat/functionbeat-"${VERSION}"-"${SYSTEM}"-"${ARCHITECTURE}".tar.gz
 
 DESTINATION=functionbeat-"${VERSION}"-"${SYSTEM}"-"${ARCHITECTURE}"
@@ -17,6 +16,7 @@ export BEAT_STRICT_PERMS=false
 export ENABLED_FUNCTION="${ENABLED_FUNCTION}"
 
 mkdir -p "${CACHE_DIR}/${ENABLED_FUNCTION}"
+ABSOLUTE_CACHE_DIR="$(cd "${CACHE_DIR}" && pwd -P)"
 
 # download functionbeat if not already in cache
 if [ ! -f "${CACHE_DIR}/${DESTINATION}.tar.gz" ]; then
@@ -43,9 +43,9 @@ cd "${DESTINATION}"-release
 # custom runtime requires the executable to be named bootstrap
 mv functionbeat-aws bootstrap
 # replace absolute local path baked in by libbeat with the Lambda runtime path
-sed -i "s|${ABSOLUTE_CACHE_DIR}/${ENABLED_FUNCTION}/${DESTINATION}|/var/task|g" functionbeat.yml
+sed "s|${ABSOLUTE_CACHE_DIR}/${ENABLED_FUNCTION}/${DESTINATION}|/var/task|g" functionbeat.yml > functionbeat.yml.tmp && mv functionbeat.yml.tmp functionbeat.yml
 touch -r bootstrap functionbeat.yml
-chmod go-w functionbeat.yml
+chmod 644 functionbeat.yml
 cd ..
 
 # zip destination contents and with deterministic file order


### PR DESCRIPTION
This PR ensures the compatibility with BSD based systems like macOS. 

Minor changes:

* `functionbeat.yml` permissions explicitly set to 644 to ensure reproducibility
* added cross packaging info to README.md